### PR TITLE
github actions: add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build-MacOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./configure
+    - run: make check
+    - run: sudo make install
+    - run: make distcheck && make distclean
+
+  build-Linux:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
+    - run: sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" || exit 1
+    - run: sudo apt-get update || exit 1
+    - run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev || exit 1
+    - run: export CC="clang-10" && export CXX="clang++-10" && ./configure && make check
+    - run: sudo make install
+    - run: export CC="clang-10" && export CXX="clang++-10" && make distcheck && make distclean
+


### PR DESCRIPTION
## Abstract

This PR enables Github actions for CI (macOS and Linux)
Tested here: https://github.com/gorazdko/bc-ur/actions/runs/364802350