### PR TITLE
Fix cppcheck warning about const parameter.

### DIFF
--- a/src/fountain-decoder.cpp
+++ b/src/fountain-decoder.cpp
@@ -25,7 +25,7 @@ FountainDecoder::Part::Part(const FountainEncoder::Part& p)
 {
 }
 
-FountainDecoder::Part::Part(PartIndexes& indexes, ByteVector& data)
+FountainDecoder::Part::Part(PartIndexes& indexes, const ByteVector& data)
     : indexes_(indexes)
     , data_(data)
 {

--- a/src/fountain-decoder.hpp
+++ b/src/fountain-decoder.hpp
@@ -52,7 +52,7 @@ private:
 
     public:
         explicit Part(const FountainEncoder::Part& p);
-        Part(PartIndexes& indexes, ByteVector& data);
+        Part(PartIndexes& indexes, const ByteVector& data);
 
         const PartIndexes& indexes() const { return indexes_; }
         const ByteVector& data() const { return data_; }


### PR DESCRIPTION
Before accepting a PR, `make lint` should pass with no warnings. But cppcheck v1.90 on Ubuntu 20.04.02 LTS gives the following warning:

```
fountain-decoder.cpp:28:63: style: Parameter 'data' can be declared with const [constParameter]
FountainDecoder::Part::Part(PartIndexes& indexes, ByteVector& data)
```

This PR fixes the warning by declaring the specified parameter const.