### PR TITLE
Add support for GNU compilers.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -29,7 +29,12 @@ RESET=`tput sgr0`
 
 COMPILER = g++
 CFLAGS += --debug -O0
-CXXFLAGS += -std=c++17 -stdlib=libc++ --debug -O0
+
+ifeq (@CXX@, g++)
+	CXXFLAGS += -std=c++17 --debug -O0
+else
+	CXXFLAGS += -std=c++17 -stdlib=libc++ --debug -O0
+endif
 
 ARFLAGS = rcs
 

--- a/src/xoshiro256.cpp
+++ b/src/xoshiro256.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "xoshiro256.hpp"
+#include <cstring>
 #include <limits>
 
 /*  Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -29,7 +29,13 @@ RESET=`tput sgr0`
 
 COMPILER = g++
 CFLAGS += --debug -O0
-CXXFLAGS += -std=c++17 -stdlib=libc++ --debug -O0
+
+CC = @CXX@
+ifeq (@CXX@, g++)
+	CXXFLAGS += -std=c++17 --debug -O0
+else
+	CXXFLAGS += -std=c++17 -stdlib=libc++ --debug -O0
+endif
 
 UNAME := $(shell uname)
 


### PR DESCRIPTION
Currently, the build with gcc/g++ is not supported and ends with an error:

`g++: error: unrecognized command line option ‘-stdlib=libc++’`

This PR adds support for GNU compilers while it retains the support for clang.

Fixes #6 